### PR TITLE
fix: npm build need the dist directeory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,32 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/tmp
+
+# dependencies
+/node_modules
+/bower_components
+
+# IDEs and editors
+/.idea
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage/*
+/libpeerconnection.log
+npm-debug.log
+testem.log
+/typings
+
+# e2e
+/e2e/*.js
+/e2e/*.map
+
+#System Files
+.DS_Store
+
+# Configuration
+/src/app/exemples/admin/.configuration.ts.tmp
+/src/app/exemples/admin/configuration.ts
+docker-compose.override.yml


### PR DESCRIPTION
Changes proposed in this pull request:
- embed the dist directory required for install via npm

Make sure those checkboxes are checked if you want to be reviewed
- [x] Your branch should be mergeable on current master
- [x] Tests should pass
- [x] Linter should pass
- [x] Code coverage should stay higher than 90%
- [x] Squash your commits to one commit and follow those recommendations about [writing good commit message](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
