### PR TITLE
Add a Dockerfile for hm-admin ; Change configuration of api routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
     "hm-admin":
-        image: node:6
+        build: ./docker/hm-admin
         command: npm start
         working_dir: /app
         ports:

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -8,7 +8,8 @@ RUN composer  create-project --no-scripts --no-dev api-platform/api-platform ./ 
 RUN  composer require api-platform/schema-generator
 
 COPY ./parameters.yml ./app/config/parameters.yml
-COPY ./schema.yml ./app/config/schema.yml
+COPY ./schema.yml     ./app/config/schema.yml
+COPY ./routing.yml    ./app/config/routing.yml
 
 RUN php ./vendor/bin/schema generate-types src/ app/config/schema.yml
 

--- a/docker/api/routing.yml
+++ b/docker/api/routing.yml
@@ -1,0 +1,11 @@
+api:
+    resource: .
+    type:     "api_platform"
+
+NelmioApiDocBundle:
+    resource: "@NelmioApiDocBundle/Resources/config/routing.yml"
+    prefix:   /doc
+
+api_hydra_vocab:
+    path: /vocab
+    defaults: { _controller: api_platform.hydra.action.documentation }

--- a/docker/hm-admin/Dockerfile
+++ b/docker/hm-admin/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:6
+
+# Install google chrome, it will be use to run units and e2e tests
+RUN \
+  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
+  apt-get update && \
+  apt-get install -y \
+      xvfb \
+      google-chrome-stable \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set local node_modules binaries directly available
+RUN echo "PATH=$PATH:/app/node_modules/.bin" >> /root/.bashrc
+ENV TRAVIS 1
+
+WORKDIR /app


### PR DESCRIPTION
Adapt dockerfiles:
- feat: install xvfb and google chrome in the hm-admin dev image (used to run tests)
- fix: adapt embededded dev api’s routing to expose /vocab entrypoint
